### PR TITLE
Add requestor interface and requestor HTTP implementation

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -27,6 +27,13 @@ load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
 # The first declaration of an external repository "wins".
 ############################################################
 
+go_repository(
+	name = "com_github_jarcoal_httpmock",
+	importpath = "github.com/jarcoal/httpmock",
+	sum = "h1:iUx3whfZWVf3jT01hQTO/Eo5sAYtB2/rqaUuOtpInww=",
+	version = "v1.3.1"
+)
+
 go_rules_dependencies()
 
 go_register_toolchains(version = "1.20.5")

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/Loptt/dns-updater
 
 go 1.22
+
+require github.com/jarcoal/httpmock v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/jarcoal/httpmock v1.3.1 h1:iUx3whfZWVf3jT01hQTO/Eo5sAYtB2/rqaUuOtpInww=
+github.com/jarcoal/httpmock v1.3.1/go.mod h1:3yb8rc4BI7TCBhFY8ng0gjuLKJNquuDNiPaZjnENuYg=

--- a/requestor/BUILD.bazel
+++ b/requestor/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "requestor",
+    srcs = [
+        "requestor_http.go",
+        "requestor_interface.go",
+    ],
+    importpath = "github.com/Loptt/dns-updater/requestor",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "requestor_test",
+    srcs = ["requestor_http_test.go"],
+    embed = [":requestor"],
+    deps = ["@com_github_jarcoal_httpmock//:go_default_library"],
+)

--- a/requestor/requestor_http.go
+++ b/requestor/requestor_http.go
@@ -1,0 +1,39 @@
+package requestor
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+)
+
+type RequestorHttp struct {
+	url string
+}
+
+const statusOk = 200
+
+func (r *RequestorHttp) Request() (string, error) {
+	resp, err := http.Get(r.url)
+	if err != nil {
+		return "", fmt.Errorf("failed to do GET request at url: %v", err)
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != statusOk {
+		return "", fmt.Errorf("request returned status code %d", resp.StatusCode)
+	}
+
+	buffer := &strings.Builder{}
+
+	n, err := io.Copy(buffer, resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse request body: %v", err)
+	}
+
+	log.Printf("Read %d bytes from request body\n", n)
+
+	return buffer.String(), nil
+}

--- a/requestor/requestor_http_test.go
+++ b/requestor/requestor_http_test.go
@@ -1,0 +1,63 @@
+package requestor
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/jarcoal/httpmock"
+)
+
+func TestRequestorHTTPRequest(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	tests := []struct {
+		description string
+		r           RequestorInterface
+		want        string
+		want_err    error
+		setup       func()
+		cleanup     func()
+	}{
+		{
+			description: "Request with 200 status",
+			r:           &RequestorHttp{url: "http://test.com"},
+			want:        "OK",
+			want_err:    nil,
+			setup: func() {
+				httpmock.Activate()
+				httpmock.RegisterResponder("GET", "http://test.com", httpmock.NewStringResponder(200, "OK"))
+			},
+			cleanup: func() { httpmock.DeactivateAndReset() },
+		},
+		{
+			description: "Request with non-OK status returns error",
+			r:           &RequestorHttp{url: "http://test.com"},
+			want:        "",
+			want_err:    errors.New("request failed with non-ok status"),
+			setup: func() {
+				httpmock.Activate()
+				httpmock.RegisterResponder("GET", "http://test.com", httpmock.NewStringResponder(401, ""))
+			},
+			cleanup: func() { httpmock.DeactivateAndReset() },
+		},
+	}
+
+	for i, test := range tests {
+		test.setup()
+		got, err := test.r.Request()
+		test.cleanup()
+
+		if test.want_err != nil {
+			if err == nil {
+				t.Errorf("Test #%d %s: want err %v, got %v", i, test.description, test.want_err, err)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("Test #%d %s: found error %v", i, test.description, err)
+			} else if got != test.want {
+				t.Errorf("Test #%d %s: got %v, want %v", i, test.description, got, test.want)
+			}
+		}
+	}
+}

--- a/requestor/requestor_interface.go
+++ b/requestor/requestor_interface.go
@@ -1,0 +1,8 @@
+package requestor
+
+// RequestorInterface provides an abstract interface to requestor object.
+// Requestors implement the business logic to connect to a remote service
+// and post an action to them.
+type RequestorInterface interface {
+	Request() (string, error)
+}


### PR DESCRIPTION
Requestor interface and requestor concrete implementation for HTTP requests are added.

The requestor interface provides a way to connect to a remot eservice to send an action. It will be used by the updater class to send the appropriate remote actions to perform the update. 

RequestorHTTP is the concrete implementation that sends HTTP GET requests, parses the body and returns it as a string to the caller.

Tested: Unit tests implemented and ran. No impact to production code as it is not yet integrated.