### PR TITLE
Implement UpdaterDuckDNS logic to make request to DuckDNS servers.

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -10,7 +10,8 @@ func main() {
 	uf := &updater.UpdaterDuckDNSFactory{}
 
 	domain := "lopttus"
-	u, err := uf.CreateUpdater(domain)
+	token := "test_token"
+	u, err := uf.CreateUpdater(domain, token)
 	if err != nil {
 		fmt.Printf("Failed to create updater with error: %v\n", err)
 	}

--- a/requestor/BUILD.bazel
+++ b/requestor/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "requestor",
     srcs = [
+        "requestor_fake.go",
         "requestor_http.go",
         "requestor_interface.go",
     ],
@@ -14,5 +15,5 @@ go_test(
     name = "requestor_test",
     srcs = ["requestor_http_test.go"],
     embed = [":requestor"],
-    deps = ["@com_github_jarcoal_httpmock//:go_default_library"],
+    deps = ["@com_github_jarcoal_httpmock//:httpmock"],
 )

--- a/requestor/requestor_fake.go
+++ b/requestor/requestor_fake.go
@@ -1,0 +1,19 @@
+package requestor
+
+import "fmt"
+
+// RequestorFake provides a fake implementation of a RequestorInterface
+// object.
+type RequestorFake struct {
+	Result  string
+	WantErr bool
+}
+
+// Request returns the specified string by r.Result. If r.WantErr is true, then
+// the function returns an error.
+func (r *RequestorFake) Request(url string) (string, error) {
+	if r.WantErr {
+		return "", fmt.Errorf("request error")
+	}
+	return r.Result, nil
+}

--- a/requestor/requestor_http.go
+++ b/requestor/requestor_http.go
@@ -10,17 +10,15 @@ import (
 
 // RequestorHttp implements the concrete RequestorInterface that sends HTTP
 // requests to remote services to perform the Request() action.
-type RequestorHttp struct {
-	url string
-}
+type RequestorHttp struct{}
 
 // Encodes the status of a successful HTTP request.
 const statusOk = 200
 
 // Calls an HTTP GET to the `url` and returns the body of the request as a
 // string.
-func (r *RequestorHttp) Request() (string, error) {
-	resp, err := http.Get(r.url)
+func (r *RequestorHttp) Request(url string) (string, error) {
+	resp, err := http.Get(url)
 	if err != nil {
 		return "", fmt.Errorf("failed to do GET request at url: %v", err)
 	}

--- a/requestor/requestor_http.go
+++ b/requestor/requestor_http.go
@@ -8,12 +8,17 @@ import (
 	"strings"
 )
 
+// RequestorHttp implements the concrete RequestorInterface that sends HTTP
+// requests to remote services to perform the Request() action.
 type RequestorHttp struct {
 	url string
 }
 
+// Encodes the status of a successful HTTP request.
 const statusOk = 200
 
+// Calls an HTTP GET to the `url` and returns the body of the request as a
+// string.
 func (r *RequestorHttp) Request() (string, error) {
 	resp, err := http.Get(r.url)
 	if err != nil {

--- a/requestor/requestor_http_test.go
+++ b/requestor/requestor_http_test.go
@@ -14,6 +14,7 @@ func TestRequestorHTTPRequest(t *testing.T) {
 	tests := []struct {
 		description string
 		r           RequestorInterface
+		url         string
 		want        string
 		want_err    error
 		setup       func()
@@ -21,7 +22,8 @@ func TestRequestorHTTPRequest(t *testing.T) {
 	}{
 		{
 			description: "Request with 200 status",
-			r:           &RequestorHttp{url: "http://test.com"},
+			r:           &RequestorHttp{},
+			url:         "http://test.com",
 			want:        "OK",
 			want_err:    nil,
 			setup: func() {
@@ -32,7 +34,8 @@ func TestRequestorHTTPRequest(t *testing.T) {
 		},
 		{
 			description: "Request with 200 status and empty body",
-			r:           &RequestorHttp{url: "http://test.com"},
+			r:           &RequestorHttp{},
+			url:         "http://test.com",
 			want:        "",
 			want_err:    nil,
 			setup: func() {
@@ -43,7 +46,8 @@ func TestRequestorHTTPRequest(t *testing.T) {
 		},
 		{
 			description: "Request with non-OK status returns error",
-			r:           &RequestorHttp{url: "http://test.com"},
+			r:           &RequestorHttp{},
+			url:         "http://test.com",
 			want:        "",
 			want_err:    errors.New("request failed with non-ok status"),
 			setup: func() {
@@ -56,7 +60,7 @@ func TestRequestorHTTPRequest(t *testing.T) {
 
 	for i, test := range tests {
 		test.setup()
-		got, err := test.r.Request()
+		got, err := test.r.Request(test.url)
 		test.cleanup()
 
 		if test.want_err != nil {

--- a/requestor/requestor_http_test.go
+++ b/requestor/requestor_http_test.go
@@ -31,6 +31,17 @@ func TestRequestorHTTPRequest(t *testing.T) {
 			cleanup: func() { httpmock.DeactivateAndReset() },
 		},
 		{
+			description: "Request with 200 status and empty body",
+			r:           &RequestorHttp{url: "http://test.com"},
+			want:        "",
+			want_err:    nil,
+			setup: func() {
+				httpmock.Activate()
+				httpmock.RegisterResponder("GET", "http://test.com", httpmock.NewStringResponder(200, ""))
+			},
+			cleanup: func() { httpmock.DeactivateAndReset() },
+		},
+		{
 			description: "Request with non-OK status returns error",
 			r:           &RequestorHttp{url: "http://test.com"},
 			want:        "",

--- a/requestor/requestor_interface.go
+++ b/requestor/requestor_interface.go
@@ -4,5 +4,5 @@ package requestor
 // Requestors implement the business logic to connect to a remote service
 // and post an action to them.
 type RequestorInterface interface {
-	Request() (string, error)
+	Request(string) (string, error)
 }

--- a/updater/BUILD.bazel
+++ b/updater/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     ],
     importpath = "github.com/Loptt/dns-updater/updater",
     visibility = ["//visibility:public"],
+    deps = ["//requestor"],
 )
 
 go_test(
@@ -18,4 +19,5 @@ go_test(
         "updater_factory_test.go",
     ],
     embed = [":updater"],
+    deps = ["//requestor"],
 )

--- a/updater/updater_duckdns.go
+++ b/updater/updater_duckdns.go
@@ -1,24 +1,46 @@
 package updater
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/Loptt/dns-updater/requestor"
+)
 
 // UpdaterDuckDNS is a concrete implementation of the UpdaterInterface object
 // that implements the logic to update DDNS records for DuckDNS
 // (https://www.duckdns.org/).
 type UpdaterDuckDNS struct {
 	domain string
+	token  string
+	r      requestor.RequestorInterface
 }
+
+// DuckDNS URL to update the DNS record.
+const duckDnsUpdateUrl = "https://www.duckdns.org/update"
+
+// DuckDNS string indicating a successful request.
+const duckDnsValidResponse = "OK"
 
 // Update function performs the action to update the DNS record.
 func (u *UpdaterDuckDNS) Update() error {
-	fmt.Printf("Updating %s\n", u.domain)
+	fullUrl := fmt.Sprintf("%s?domains=%s&token=%s", duckDnsUpdateUrl, u.domain, u.token)
+	result, err := u.r.Request(fullUrl)
+	if err != nil {
+		return fmt.Errorf("failed to request to domain %s: %v", u.domain, err)
+	}
+
+	if result != duckDnsValidResponse {
+		return fmt.Errorf("response returned by DuckDNS is invalid, got %s, expected %s", result, duckDnsValidResponse)
+	}
 
 	return nil
 }
 
-// MakeUopdaterDuckDNS creates a new UpdaterDuckDNS object.
-func MakeUpdaterDuckDNS(domain string) *UpdaterDuckDNS {
+// NewUpdaterDuckDNS creates a new UpdaterDuckDNS object.
+func NewUpdaterDuckDNS(domain, token string, r requestor.RequestorInterface) *UpdaterDuckDNS {
 	return &UpdaterDuckDNS{
 		domain: domain,
+		token:  token,
+		r:      r,
 	}
 }

--- a/updater/updater_duckdns_test.go
+++ b/updater/updater_duckdns_test.go
@@ -1,6 +1,7 @@
 package updater
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/Loptt/dns-updater/requestor"
@@ -17,12 +18,24 @@ func TestUpdate(t *testing.T) {
 			want:        nil,
 			u:           NewUpdaterDuckDNS("test_domain", "test_token", &requestor.RequestorFake{Result: "OK", WantErr: false}),
 		},
+		{
+			description: "Update with error in requestor",
+			want:        errors.New("Test error"),
+			u:           NewUpdaterDuckDNS("test_domain", "test_token", &requestor.RequestorFake{Result: "OK", WantErr: true}),
+		},
+		{
+			description: "Update with wrong return string",
+			want:        errors.New("Test error"),
+			u:           NewUpdaterDuckDNS("test_domain", "test_token", &requestor.RequestorFake{Result: "BAD", WantErr: false}),
+		},
 	}
 
 	for i, test := range tests {
 		got := test.u.Update()
 
-		if got != test.want {
+		if test.want == nil && got != nil {
+			t.Errorf("Test #%d %s: want %v got %v", i, test.description, test.want, got)
+		} else if test.want != nil && got == nil {
 			t.Errorf("Test #%d %s: want %v got %v", i, test.description, test.want, got)
 		}
 	}

--- a/updater/updater_duckdns_test.go
+++ b/updater/updater_duckdns_test.go
@@ -1,6 +1,10 @@
 package updater
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/Loptt/dns-updater/requestor"
+)
 
 func TestUpdate(t *testing.T) {
 	tests := []struct {
@@ -9,9 +13,9 @@ func TestUpdate(t *testing.T) {
 		u           UpdaterInterface
 	}{
 		{
-			description: "Update with no error",
+			description: "Update with OK status",
 			want:        nil,
-			u:           MakeUpdaterDuckDNS("test_domain"),
+			u:           NewUpdaterDuckDNS("test_domain", "test_token", &requestor.RequestorFake{Result: "OK", WantErr: false}),
 		},
 	}
 

--- a/updater/updater_factory.go
+++ b/updater/updater_factory.go
@@ -1,21 +1,19 @@
 package updater
 
-import "fmt"
+import (
+	"fmt"
 
-// UpdaterFactoryInterface provides an abstract interface to create
-// UpdaterInterface concrete implementations.
-type UpdaterFactoryInterface interface {
-	CreateUpdater(string) (UpdaterInterface, error)
-}
+	"github.com/Loptt/dns-updater/requestor"
+)
 
-// UpdaterDuckDNSFactory is a concrete implementation of the
-// UpdaterFactoryInterface that creates UpdaterDuckDNS objects.
+// UpdaterDuckDNSFactory is a factory object that creates UpdaterDuckDNS
+// objects.
 type UpdaterDuckDNSFactory struct{}
 
 // CreateUpdater creates an updater object of DuckDNS type.
-func (uf *UpdaterDuckDNSFactory) CreateUpdater(domain string) (UpdaterInterface, error) {
+func (uf *UpdaterDuckDNSFactory) CreateUpdater(domain, token string) (UpdaterInterface, error) {
 	if len(domain) < 1 {
 		return nil, fmt.Errorf("empty string vwas provided as domain name")
 	}
-	return MakeUpdaterDuckDNS(domain), nil
+	return NewUpdaterDuckDNS(domain, token, &requestor.RequestorHttp{}), nil
 }

--- a/updater/updater_factory_test.go
+++ b/updater/updater_factory_test.go
@@ -8,29 +8,27 @@ import (
 func TestCreateUpdaterDuckDNS(t *testing.T) {
 	tests := []struct {
 		description string
-		uf          UpdaterFactoryInterface
-		u           UpdaterInterface
+		uf          *UpdaterDuckDNSFactory
 		domain      string
+		token       string
 		want_err    error
 	}{
 		{
 			description: "Create with no error",
 			uf:          &UpdaterDuckDNSFactory{},
-			u:           MakeUpdaterDuckDNS("test_domain"),
 			domain:      "test_domain",
 			want_err:    nil,
 		},
 		{
 			description: "Create with empty domain",
 			uf:          &UpdaterDuckDNSFactory{},
-			u:           MakeUpdaterDuckDNS(""),
 			domain:      "",
 			want_err:    errors.New("domain is empty"),
 		},
 	}
 
 	for i, test := range tests {
-		got, err := test.uf.CreateUpdater(test.domain)
+		got, err := test.uf.CreateUpdater(test.domain, test.token)
 
 		if test.want_err != nil {
 			if err == nil {


### PR DESCRIPTION
Added logic un UpdaterDuckDNS.Update to form appropriate string and make the HTTP request via RequestorHTTP to DuckDNS. Cleaned up Factory classes and added more test cases to unit tests.