### PR TITLE
Add bazel rules to generate and load docker images

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@bazel_gazelle//:def.bzl", "gazelle")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
-load("@rules_oci//oci:defs.bzl", "oci_image")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_tarball")
 
 # gazelle:prefix github.com/Loptt/dns-updater
 gazelle(name = "gazelle")
@@ -12,8 +12,15 @@ pkg_tar(
 )
 
 oci_image(
-    name = "image",
+    name = "dns_updater",
     base = "@distroless_base",
-    entrypoint = ["/app"],
     tars = [":run_tar"],
+    entrypoint = ["/cmd"],
 )
+
+oci_tarball(
+    name = "dns_updater_load",
+    image = ":dns_updater",
+    repo_tags = ["dns-updater:latest"],
+)
+

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,4 +1,19 @@
 load("@bazel_gazelle//:def.bzl", "gazelle")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+load("@rules_oci//oci:defs.bzl", "oci_image")
 
 # gazelle:prefix github.com/Loptt/dns-updater
 gazelle(name = "gazelle")
+
+pkg_tar(
+    name = "run_tar",
+    srcs = ["//cmd:cmd"],
+
+)
+
+oci_image(
+    name = "image",
+    base = "@distroless_base",
+    entrypoint = ["/app"],
+    tars = [":run_tar"],
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -18,8 +18,66 @@ http_archive(
 	]
 )
 
+http_archive(
+    name = "rules_pkg",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/1.0.1/rules_pkg-1.0.1.tar.gz",
+        "https://github.com/bazelbuild/rules_pkg/releases/download/1.0.1/rules_pkg-1.0.1.tar.gz",
+    ],
+    sha256 = "d20c951960ed77cb7b341c2a59488534e494d5ad1d30c4818c736d57772a9fef",
+)
+
+http_archive(
+    name = "rules_oci",
+    sha256 = "46ce9edcff4d3d7b3a550774b82396c0fa619cc9ce9da00c1b09a08b45ea5a14",
+    strip_prefix = "rules_oci-1.8.0",
+    url = "https://github.com/bazel-contrib/rules_oci/releases/download/v1.8.0/rules_oci-v1.8.0.tar.gz",
+)
+
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
+
+go_rules_dependencies()
+
+go_register_toolchains(version = "1.20.5")
+
+gazelle_dependencies()
+
+load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
+
+rules_pkg_dependencies()
+
+#################################
+# Rules OCI For docker rules
+################################
+
+load("@rules_oci//oci:dependencies.bzl", "rules_oci_dependencies")
+
+rules_oci_dependencies()
+
+load("@rules_oci//oci:repositories.bzl", "LATEST_CRANE_VERSION", "oci_register_toolchains")
+
+oci_register_toolchains(
+    name = "oci",
+    crane_version = LATEST_CRANE_VERSION,
+    # Uncommenting the zot toolchain will cause it to be used instead of crane for some tasks.
+    # Note that it does not support docker-format images.
+    # zot_version = LATEST_ZOT_VERSION,
+)
+
+# You can pull your base images using oci_pull like this:
+load("@rules_oci//oci:pull.bzl", "oci_pull")
+
+oci_pull(
+    name = "distroless_base",
+    digest = "sha256:ccaef5ee2f1850270d453fdf700a5392534f8d1a8ca2acda391fbb6a06b81c86",
+    image = "gcr.io/distroless/base",
+    platforms = [
+        "linux/amd64",
+        "linux/arm64",
+    ],
+)
 
 ############################################################
 # Define your own dependencies here using go_repository.
@@ -40,10 +98,3 @@ go_repository(
 	sum = "h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=",
 	version = "v3.0.1"
 )
-
-go_rules_dependencies()
-
-go_register_toolchains(version = "1.20.5")
-
-gazelle_dependencies()
-

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -66,16 +66,14 @@ oci_register_toolchains(
     # zot_version = LATEST_ZOT_VERSION,
 )
 
-# You can pull your base images using oci_pull like this:
 load("@rules_oci//oci:pull.bzl", "oci_pull")
 
 oci_pull(
     name = "distroless_base",
-    digest = "sha256:ccaef5ee2f1850270d453fdf700a5392534f8d1a8ca2acda391fbb6a06b81c86",
-    image = "gcr.io/distroless/base",
+    digest = "sha256:a7af3ef5d69f6534ba0492cc7d6b8fbcffddcb02511b45becc2fac752f907584",
+    image = "gcr.io/distroless/base-debian12",
     platforms = [
         "linux/amd64",
-        "linux/arm64",
     ],
 )
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/Loptt/dns-updater/config"
@@ -27,6 +28,8 @@ func Run() error {
 	if err != nil {
 		return fmt.Errorf("failed to load config with error: %v", err)
 	}
+
+	log.Printf("Loaded config from %s, value is %v", *configPathFlag, *config)
 
 	// TODO(Loptt): Change this value to come from env variable.
 	token := "test_token"


### PR DESCRIPTION
Docker images can now be automatically generated by using bazel rules from https://github.com/bazel-contrib/rules_oci.

- bazel run //:dns_updater builds the OCI (docker) image
- bazel run //:dns_updater_load takes the docker image and uploads it to the docker daemon to run in the machine.

Tested:

```
lopttus@ubuntu-poweredge:/tmp/dns-updater$ blaze run //:dns_updater_load
INFO: Analyzed target //:dns_updater_load (128 packages loaded, 9960 targets configured).
INFO: Found 1 target...
Target //:dns_updater_load up-to-date:
bazel-bin/dns_updater_load/tarball.tar
INFO: Elapsed time: 4.281s, Critical Path: 0.06s
INFO: 2 processes: 2 internal.
INFO: Build completed successfully, 2 total action
INFO: Running command line: bazel-bin/dns_updater_load.sh
Loaded image: dns-updater:latest
lopttus@ubuntu-poweredge:/tmp/dns-updater$ docker run --mount type=bind,source=/etc/dns_updater/config.yaml,target=/etc/dns_updater/config.yaml dns-updater:latest
2024/08/04 19:37:18 Loaded config from /etc/dns_updater/config.yaml, value is {43200 lopttus} 
^Ccontext canceled                                                                           
```